### PR TITLE
Use live site base URL for relative URLs during post-deploy link checks

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -53,7 +53,7 @@ jobs:
         with:
           args: >
             --offline
-            --base ./public
+            --base-url ./public
             --no-progress
             --verbose
             './public/**/*.html'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -53,7 +53,7 @@ jobs:
         with:
           args: >
             --offline
-            --base-url ./public
+            --base ./public
             --no-progress
             --verbose
             './public/**/*.html'

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -54,7 +54,7 @@ jobs:
         with:
           args: >
             --include https://nandstand.github.io/hugo-sandbox
-            --base ./public
+            --base-url https://nandstand.github.io/hugo-sandbox
             --no-progress
             --verbose
             --accept 200,206

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -54,7 +54,7 @@ jobs:
         with:
           args: >
             --include https://nandstand.github.io/hugo-sandbox
-            --base-url https://nandstand.github.io/hugo-sandbox
+            --base https://nandstand.github.io/hugo-sandbox
             --no-progress
             --verbose
             --accept 200,206


### PR DESCRIPTION
- ~~Workflow files were using deprecated option `base`, updated to use `base-url` in both.~~
- Link checker should use the base URL for relative URL checks instead of treating them like files in `./public`, which was causing them to be ignored.